### PR TITLE
Start RRAS before set up NAT when setup per-host-subnet in windows

### DIFF
--- a/startup_per-host-subnet.ps1
+++ b/startup_per-host-subnet.ps1
@@ -275,8 +275,8 @@ if("$subnet" -ne ""){
     $ifIndex= GenerateNetwork $subnet $adapterName
 }
 $_=(netsh advfirewall set allprofile state off)
-SetupRRASNat
 RestartRRAS
+SetupRRASNat
 SetMetadataRoute $ifIndex
 $service=get-service rancher-per-host-subnet -ErrorAction Ignore
 if($service -ne $null){


### PR DESCRIPTION
refer to bug https://github.com/rancher/rancher/issues/10544
It will cause NAT set up fail if not fix.